### PR TITLE
Feature/temporal measure

### DIFF
--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -300,16 +300,20 @@ void Simulation::clear_bodies() {
 }
 
 // Write a set of vtu files for the particles and panels
-std::vector<std::string> Simulation::write_vtk(const int _index) {
+std::vector<std::string> Simulation::write_vtk(const int _index,
+                                               const bool _do_bdry,
+                                               const bool _do_flow,
+                                               const bool _do_measure) {
 
   // solve the BEM (before any VTK or status file output)
   //std::cout << "Updating element vels" << std::endl;
   std::array<double,2> thisfs = {fs[0], fs[1]};
   //clear_inner_layer<STORE>(1, bdry, vort, 1.0/std::sqrt(2.0*M_PI), get_ips());
   solve_bem<STORE,ACCUM,Int>(time, thisfs, vort, bdry, bem);
-  conv.find_vels(thisfs, vort, bdry, vort);
-  conv.find_vels(thisfs, vort, bdry, fldpt);
-  conv.find_vels(thisfs, vort, bdry, bdry);
+
+  if (_do_flow)    conv.find_vels(thisfs, vort, bdry, vort);
+  if (_do_measure) conv.find_vels(thisfs, vort, bdry, fldpt);
+  if (_do_bdry)    conv.find_vels(thisfs, vort, bdry, bdry);
 
   // may eventually want to avoid clobbering by maintaining an internal count of the
   //   number of simulations run from this execution of the GUI
@@ -324,9 +328,9 @@ std::vector<std::string> Simulation::write_vtk(const int _index) {
   }
 
   // ask Vtk to write files for each collection
-  write_vtk_files<float>(vort, stepnum, files);
-  write_vtk_files<float>(fldpt, stepnum, files);
-  write_vtk_files<float>(bdry, stepnum, files);
+  if (_do_flow)    write_vtk_files<float>(vort, stepnum, files);
+  if (_do_measure) write_vtk_files<float>(fldpt, stepnum, files);
+  if (_do_bdry)    write_vtk_files<float>(bdry, stepnum, files);
 
   return files;
 }

--- a/src/Simulation.h
+++ b/src/Simulation.h
@@ -124,7 +124,10 @@ public:
   bool do_any_bodies_move();
   bool any_nonzero_bcs();
   bool test_for_new_results();
-  std::vector<std::string> write_vtk(const int _index = -1);
+  std::vector<std::string> write_vtk(const int _index = -1,
+                                     const bool _do_bdry = true,
+                                     const bool _do_flow = true,
+                                     const bool _do_measure = true);
   bool test_vs_stop();
   bool test_vs_stop_async();
 

--- a/src/VtkXmlHelper.h
+++ b/src/VtkXmlHelper.h
@@ -25,7 +25,7 @@
 
 
 //
-// compress a byte stream
+// compress a byte stream - TO DO
 //
 
 
@@ -144,6 +144,16 @@ void write_DataArray (tinyxml2::XMLPrinter& _p,
 // see the full vtk spec here:
 // https://vtk.org/wp-content/uploads/2015/04/file-formats.pdf
 //
+// time can be written to a vtk file:
+// https://gitlab.kitware.com/vtk/vtk/commit/6e0acf3b773f120c3b8319c4078a4eac9ed31ce1
+//
+// <PolyData>
+//      <FieldData>
+//        <DataArray type="Float64" Name="TimeValue" NumberOfTuples="1">1.24
+//        </DataArray>
+//      </FieldData>
+
+//
 template <class S>
 std::string write_vtu_points(Points<S> const& pts, const size_t file_idx, const size_t frameno) {
 
@@ -182,8 +192,12 @@ std::string write_vtu_points(Points<S> const& pts, const size_t file_idx, const 
 
   // push comment with sim time?
 
+  // must choose one of these two formats
   printer.OpenElement( "UnstructuredGrid" );
   //printer.OpenElement( "PolyData" );
+
+  // include time here as FieldData?
+
   printer.OpenElement( "Piece" );
   printer.PushAttribute( "NumberOfPoints", std::to_string(pts.get_n()).c_str() );
   printer.PushAttribute( "NumberOfCells", std::to_string(pts.get_n()).c_str() );
@@ -355,8 +369,12 @@ std::string write_vtu_panels(Surfaces<S> const& surf, const size_t file_idx, con
 
   // push comment with sim time?
 
+  // must choose one of these two formats
   printer.OpenElement( "UnstructuredGrid" );
   //printer.OpenElement( "PolyData" );
+
+  // put time in here as FieldData?
+
   printer.OpenElement( "Piece" );
   printer.PushAttribute( "NumberOfPoints", std::to_string(surf.get_n()).c_str() );
   printer.PushAttribute( "NumberOfCells", std::to_string(surf.get_npanels()).c_str() );

--- a/src/main_gui.cpp
+++ b/src/main_gui.cpp
@@ -1077,8 +1077,10 @@ int main(int argc, char const *argv[]) {
       pngfn << "img_" << std::setfill('0') << std::setw(5) << frameno << ".png";
       png_out_file = pngfn.str();
       (void) saveFramePNG(png_out_file);
-      if (write_png_immediately) std::cout << "Wrote screenshot to " << png_out_file << std::endl;
+      std::cout << "Wrote screenshot to " << png_out_file << std::endl;
       frameno++;
+      // no need to tell the user every frame
+      if (export_png_when_ready) png_out_file.clear();
       write_png_immediately = false;
       export_png_when_ready = false;
     }


### PR DESCRIPTION
Instead of implementing a special measurement point which stores a time-series of its velocity, which would have required special file output instructions, we instead provide for "write every frame" checkboxes for all 3 feature types plus screenshot to PNG. This keeps the interface simple and allows ParaView to read in them all as a time series.